### PR TITLE
additional image descriptions for every image in replies for fun

### DIFF
--- a/twitterBotAPI.py
+++ b/twitterBotAPI.py
@@ -252,9 +252,9 @@ def gen_additional_prediction_string(prediction, img_path):
     confidence_calcs[1] = confidence.calc_confidence_idx(img_path, prediction[2][2])
     confidence_calcs[2] = confidence.calc_confidence_idx(img_path, prediction[2][3])
     message = 'additional image predictions:\n'
-    message += '- ' + prediction[0][1] + ' (confidence: ' + str(round(confidence_calced[0]*100, 2)) + '%)\n'
-    message += '- ' + prediction[0][2] + ' (confidence: ' + str(round(confidence_calced[1]*100, 2)) + '%)\n'
-    message += '- ' + prediction[0][3] + ' (confidence: ' + str(round(confidence_calced[2]*100, 2)) + '%)\n'
+    message += '- ' + prediction[0][1] + ' (confidence: ' + str(round(confidence_calcs[0]*100, 2)) + '%)\n'
+    message += '- ' + prediction[0][2] + ' (confidence: ' + str(round(confidence_calcs[1]*100, 2)) + '%)\n'
+    message += '- ' + prediction[0][3] + ' (confidence: ' + str(round(confidence_calcs[2]*100, 2)) + '%)\n'
     return message
 
 def peek_prediction(img_path):


### PR DESCRIPTION
i just made it do the thing it does for boring predictions for all predictions but as a reply to itself instead. i just think it'd be interesting to see all of the other predictions. i haven't tested it but it should probably work, and i don't even think there's any bitcoin miners in this one. i did it entirely in the github editor because i was lazy, so if it breaks that's probably why.